### PR TITLE
feature/EODHP-333-generate-platform-user-workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ go.work
 *.swp
 *.swo
 *~
+
+# Ignore helm package files
+*.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ RUN go mod download
 COPY cmd/main.go cmd/main.go
 COPY api/ api/
 COPY internal/ internal/
-COPY templates/ templates/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
@@ -27,8 +26,10 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
-WORKDIR /
+
+WORKDIR /app/bin
+COPY templates/ ../templates/
 COPY --from=builder /workspace/manager .
 USER 65532:65532
 
-ENTRYPOINT ["/manager"]
+ENTRYPOINT ["./manager"]

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,16 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: kustomize ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/default | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
+HELMIFY ?= $(LOCALBIN)/helmify
+
+.PHONY: helmify
+helmify: $(HELMIFY) ## Download helmify locally if necessary.
+$(HELMIFY): $(LOCALBIN)
+	test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
+    
+helm: manifests kustomize helmify
+	$(KUSTOMIZE) build config/default | $(HELMIFY) $(CHART)
+
 ##@ Dependencies
 
 ## Location to install dependencies to

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ make run  # run a local instance of the controller
 ## Run in Cluster
 
 ```bash
+make manifests  # generate the latest manifests
 make install  # installs CRDs to the cluster
-make docker-build docker-push IMG=<some-registry>/<project-name>:tag  # build controller
+make docker-build docker-push IMG=<some-registry>/<project-name>:tag  # build and push controller
 make deploy IMG=<some-registry>/<project-name>:tag  # deploy controller to cluster
 ```
 
@@ -33,7 +34,7 @@ make undeploy  # remove controller from the cluster
 ## Install CRDs
 
 ```bash
-make manifests  # generate the CRDs
+make install # installs CRDs to the cluster
 ```
 
 ## Development
@@ -46,6 +47,21 @@ After updating any api/**/*_types.go files run:
 make manifests  # generate the manifests
 make  # regenerate the code
 make install  # install the CRDs to the cluster
+```
+
+### Generate Helm Chart
+
+To update the Helm chart:
+
+```bash
+make helm CHART=chart/workspace-operator
+```
+
+To publish the Helm chart:
+
+```bash
+helm package chart/workspace-operator
+helm push workspace-operator-0.1.0.tgz oci://public.ecr.aws/n1b3o1k2/helm
 ```
 
 ## Manually Export Manifests

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ To update the Helm chart:
 make helm CHART=chart/workspace-operator
 ```
 
+__Be careful not to overwrite manual changes to the Helm manifests. Always commit to Git just before applying `make helm` and compare changes, reverting the change where the modification undoes manual changes.__
+
 To publish the Helm chart:
 
 ```bash
 helm package chart/workspace-operator
-helm push workspace-operator-0.1.0.tgz oci://public.ecr.aws/n1b3o1k2/helm
+helm push workspace-operator-x.y.z.tgz oci://public.ecr.aws/n1b3o1k2/helm
 ```
 
 ## Manually Export Manifests

--- a/chart/workspace-operator/.helmignore
+++ b/chart/workspace-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/workspace-operator/Chart.yaml
+++ b/chart/workspace-operator/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: workspace-operator
+description: A Helm chart for Kubernetes
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.2.0"

--- a/chart/workspace-operator/Chart.yaml
+++ b/chart/workspace-operator/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/chart/workspace-operator/templates/_helpers.tpl
+++ b/chart/workspace-operator/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "workspace-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "workspace-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "workspace-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "workspace-operator.labels" -}}
+helm.sh/chart: {{ include "workspace-operator.chart" . }}
+{{ include "workspace-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "workspace-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "workspace-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "workspace-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "workspace-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/workspace-operator/templates/deployment.yaml
+++ b/chart/workspace-operator/templates/deployment.yaml
@@ -21,14 +21,14 @@ spec:
       {{- include "workspace-operator.selectorLabels" . | nindent 8 }}
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        checksum/config: {{ include (print .Template.BasePath "/manager-config.yaml") . | sha256sum }}
     spec:
       containers:
       - args: {{- toYaml .Values.controllerManager.kubeRbacProxy.args | nindent 8 }}
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.controllerManager.kubeRbacProxy.image.repository }}:{{ .Values.controllerManager.kubeRbacProxy.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.controllerManager.kubeRbacProxy.image.repository }}:{{ .Values.controllerManager.kubeRbacProxy.image.tag | default .Chart.AppVersion }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -40,12 +40,11 @@ spec:
           | nindent 10 }}
       - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
         command:
-        - /manager
+        - /manager --config /var/config.yaml
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
-        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
-          | default .Chart.AppVersion }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -63,6 +62,13 @@ spec:
           }}
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
+        volumeMounts:
+        - mountPath: /var/config.yaml
+          name: config
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "workspace-operator.fullname" . }}-controller-manager
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "workspace-operator.fullname" . }}-controller-manager

--- a/chart/workspace-operator/templates/deployment.yaml
+++ b/chart/workspace-operator/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-controller-manager
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: workspace-operator
+    app.kubernetes.io/part-of: workspace-operator
+    control-plane: controller-manager
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.controllerManager.replicas }}
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+    {{- include "workspace-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        control-plane: controller-manager
+      {{- include "workspace-operator.selectorLabels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+    spec:
+      containers:
+      - args: {{- toYaml .Values.controllerManager.kubeRbacProxy.args | nindent 8 }}
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.controllerManager.kubeRbacProxy.image.repository }}:{{ .Values.controllerManager.kubeRbacProxy.image.tag
+          | default .Chart.AppVersion }}
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources: {{- toYaml .Values.controllerManager.kubeRbacProxy.resources | nindent
+          10 }}
+        securityContext: {{- toYaml .Values.controllerManager.kubeRbacProxy.containerSecurityContext
+          | nindent 10 }}
+      - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
+        command:
+        - /manager
+        env:
+        - name: KUBERNETES_CLUSTER_DOMAIN
+          value: {{ quote .Values.kubernetesClusterDomain }}
+        image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
+          | default .Chart.AppVersion }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
+          }}
+        securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
+          | nindent 10 }}
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: {{ include "workspace-operator.fullname" . }}-controller-manager
+      terminationGracePeriodSeconds: 10

--- a/chart/workspace-operator/templates/deployment.yaml
+++ b/chart/workspace-operator/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.kubeRbacProxy.image.repository }}:{{ .Values.controllerManager.kubeRbacProxy.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443
@@ -38,13 +39,13 @@ spec:
           10 }}
         securityContext: {{- toYaml .Values.controllerManager.kubeRbacProxy.containerSecurityContext
           | nindent 10 }}
-      - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
-        command:
-        - /manager --config /var/config.yaml
+      - args: 
+        - --config=/app/config.yaml {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
         env:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
+        imagePullPolicy: {{ .Values.imagePullPolicy }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -63,12 +64,13 @@ spec:
         securityContext: {{- toYaml .Values.controllerManager.manager.containerSecurityContext
           | nindent 10 }}
         volumeMounts:
-        - mountPath: /var/config.yaml
-          name: config
+        - name: config
+          mountPath: /app/config.yaml
+          subPath: config.yaml
       volumes:
         - name: config
           configMap:
-            name: {{ include "workspace-operator.fullname" . }}-controller-manager
+            name: {{ include "workspace-operator.fullname" . }}-config
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "workspace-operator.fullname" . }}-controller-manager

--- a/chart/workspace-operator/templates/leader-election-rbac.yaml
+++ b/chart/workspace-operator/templates/leader-election-rbac.yaml
@@ -1,0 +1,59 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-leader-election-role
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: workspace-operator
+    app.kubernetes.io/part-of: workspace-operator
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-leader-election-rolebinding
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: workspace-operator
+    app.kubernetes.io/part-of: workspace-operator
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ include "workspace-operator.fullname" . }}-leader-election-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "workspace-operator.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/chart/workspace-operator/templates/manager-config.yaml
+++ b/chart/workspace-operator/templates/manager-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-config
+data:
+  {{- .Values.controllerManager.config | toYaml | nindent 2 }}

--- a/chart/workspace-operator/templates/manager-config.yaml
+++ b/chart/workspace-operator/templates/manager-config.yaml
@@ -3,4 +3,6 @@ kind: ConfigMap
 metadata:
   name: {{ include "workspace-operator.fullname" . }}-config
 data:
-  {{- .Values.controllerManager.config | toYaml | nindent 2 }}
+  config.yaml: |
+    {{- .Values.controllerManager.config | toYaml | nindent 4 }}
+    

--- a/chart/workspace-operator/templates/manager-rbac.yaml
+++ b/chart/workspace-operator/templates/manager-rbac.yaml
@@ -1,8 +1,9 @@
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: {{ include "workspace-operator.fullname" . }}-manager-role
+  labels:
+  {{- include "workspace-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -78,3 +79,21 @@ rules:
   - get
   - patch
   - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-manager-rolebinding
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: workspace-operator
+    app.kubernetes.io/part-of: workspace-operator
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "workspace-operator.fullname" . }}-manager-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "workspace-operator.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/chart/workspace-operator/templates/metrics-reader-rbac.yaml
+++ b/chart/workspace-operator/templates/metrics-reader-rbac.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-metrics-reader
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: workspace-operator
+    app.kubernetes.io/part-of: workspace-operator
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/chart/workspace-operator/templates/metrics-service.yaml
+++ b/chart/workspace-operator/templates/metrics-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-controller-manager-metrics-service
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: workspace-operator
+    app.kubernetes.io/part-of: workspace-operator
+    control-plane: controller-manager
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.metricsService.type }}
+  selector:
+    control-plane: controller-manager
+  {{- include "workspace-operator.selectorLabels" . | nindent 4 }}
+  ports:
+	{{- .Values.metricsService.ports | toYaml | nindent 2 }}

--- a/chart/workspace-operator/templates/proxy-rbac.yaml
+++ b/chart/workspace-operator/templates/proxy-rbac.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-proxy-role
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: workspace-operator
+    app.kubernetes.io/part-of: workspace-operator
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-proxy-rolebinding
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: workspace-operator
+    app.kubernetes.io/part-of: workspace-operator
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: '{{ include "workspace-operator.fullname" . }}-proxy-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ include "workspace-operator.fullname" . }}-controller-manager'
+  namespace: '{{ .Release.Namespace }}'

--- a/chart/workspace-operator/templates/serviceaccount.yaml
+++ b/chart/workspace-operator/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "workspace-operator.fullname" . }}-controller-manager
+  labels:
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}

--- a/chart/workspace-operator/templates/workspace-crd.yaml
+++ b/chart/workspace-operator/templates/workspace-crd.yaml
@@ -1,0 +1,121 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: workspaces.core.telespazio-uk.io
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  labels:
+  {{- include "workspace-operator.labels" . | nindent 4 }}
+spec:
+  group: core.telespazio-uk.io
+  names:
+    kind: Workspace
+    listKind: WorkspaceList
+    plural: workspaces
+    singular: workspace
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Workspace is the Schema for the workspaces API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WorkspaceSpec defines the desired state of Workspace
+            properties:
+              namespace:
+                description: Namespace to create for the workspace
+                type: string
+              serviceAccount:
+                description: Service account
+                properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Service account annotations
+                    type: object
+                  name:
+                    type: string
+                type: object
+              storage:
+                description: Storage parameters
+                properties:
+                  awsEFS:
+                    description: Define the EFS storage
+                    properties:
+                      rootDirectory:
+                        type: string
+                      user:
+                        properties:
+                          gid:
+                            format: int64
+                            type: integer
+                          uid:
+                            format: int64
+                            type: integer
+                        type: object
+                    type: object
+                  pvName:
+                    description: Persistent volume claim name
+                    type: string
+                  pvcName:
+                    description: Persistent volume claim name
+                    type: string
+                  size:
+                    description: Size of the storage
+                    type: string
+                  storageClass:
+                    description: Kubernetes storage class to use
+                    type: string
+                type: object
+              username:
+                description: The username of the user
+                type: string
+            type: object
+          status:
+            description: WorkspaceStatus defines the observed state of Workspace
+            properties:
+              awsRole:
+                description: The AWS Role created for the user's workspace
+                type: string
+              namespace:
+                description: Name of child namespace
+                type: string
+              storage:
+                description: Storage parameters
+                properties:
+                  awsEFS:
+                    properties:
+                      accessPointID:
+                        type: string
+                    type: object
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/chart/workspace-operator/values.yaml
+++ b/chart/workspace-operator/values.yaml
@@ -1,0 +1,53 @@
+controllerManager:
+  kubeRbacProxy:
+    args:
+    - --secure-listen-address=0.0.0.0:8443
+    - --upstream=http://127.0.0.1:8080/
+    - --logtostderr=true
+    - --v=0
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    image:
+      repository: gcr.io/kubebuilder/kube-rbac-proxy
+      tag: v0.15.0
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 5m
+        memory: 64Mi
+  manager:
+    args:
+    - --health-probe-bind-address=:8081
+    - --metrics-bind-address=127.0.0.1:8080
+    - --leader-elect
+    containerSecurityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+    image:
+      repository: public.ecr.aws/n1b3o1k2/workspace-controller
+      tag: 0.2.0
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 10m
+        memory: 64Mi
+  replicas: 1
+  serviceAccount:
+    annotations: {}
+kubernetesClusterDomain: cluster.local
+metricsService:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  type: ClusterIP

--- a/chart/workspace-operator/values.yaml
+++ b/chart/workspace-operator/values.yaml
@@ -1,15 +1,15 @@
 controllerManager:
   kubeRbacProxy:
     args:
-    - --secure-listen-address=0.0.0.0:8443
-    - --upstream=http://127.0.0.1:8080/
-    - --logtostderr=true
-    - --v=0
+      - --secure-listen-address=0.0.0.0:8443
+      - --upstream=http://127.0.0.1:8080/
+      - --logtostderr=true
+      - --v=0
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL
+          - ALL
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.15.0
@@ -22,14 +22,14 @@ controllerManager:
         memory: 64Mi
   manager:
     args:
-    - --health-probe-bind-address=:8081
-    - --metrics-bind-address=127.0.0.1:8080
-    - --leader-elect
+      - --health-probe-bind-address=:8081
+      - --metrics-bind-address=127.0.0.1:8080
+      - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL
+          - ALL
     image:
       repository: public.ecr.aws/n1b3o1k2/workspace-controller
       tag: 0.2.0
@@ -43,11 +43,22 @@ controllerManager:
   replicas: 1
   serviceAccount:
     annotations: {}
+  config:
+    clusterName:
+    storage:
+      defaultSize:
+    aws:
+      accountID:
+      region:
+      oidc:
+        provider:
+      storage:
+        efsID:
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:
-  - name: https
-    port: 8443
-    protocol: TCP
-    targetPort: https
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
   type: ClusterIP

--- a/chart/workspace-operator/values.yaml
+++ b/chart/workspace-operator/values.yaml
@@ -1,3 +1,6 @@
+fullnameOverride: workspace
+imagePullPolicy: IfNotPresent
+
 controllerManager:
   kubeRbacProxy:
     args:
@@ -43,17 +46,6 @@ controllerManager:
   replicas: 1
   serviceAccount:
     annotations: {}
-  config:
-    clusterName:
-    storage:
-      defaultSize:
-    aws:
-      accountID:
-      region:
-      oidc:
-        provider:
-      storage:
-        efsID:
 kubernetesClusterDomain: cluster.local
 metricsService:
   ports:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -66,37 +66,37 @@ spec:
         # seccompProfile:
         #   type: RuntimeDefault
       containers:
-      - command:
-        - /manager
-        args:
-        - --leader-elect
-        image: controller:latest
-        name: manager
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - "ALL"
-        livenessProbe:
-          httpGet:
-            path: /healthz
-            port: 8081
-          initialDelaySeconds: 15
-          periodSeconds: 20
-        readinessProbe:
-          httpGet:
-            path: /readyz
-            port: 8081
-          initialDelaySeconds: 5
-          periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 10m
-            memory: 64Mi
+        - command:
+            - /manager
+          args:
+            - --leader-elect
+          image: controller:latest
+          name: manager
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - "ALL"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # TODO(user): Configure the resources accordingly based on the project requirements.
+          # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -65,7 +65,9 @@ func NewWorkspaceReconciler(client client.Client, scheme *runtime.Scheme,
 //+kubebuilder:rbac:groups=core.telespazio-uk.io,resources=workspaces/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=core.telespazio-uk.io,resources=workspaces/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=core,resources=persistentvolume,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=persistentvolumes,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
The main change to the workspace operator was adding a Helm chart so that it is easier to deploy and parameterise. To generate the boiler place I used Helmify, and added commands to the make file to scaffold the helm chart. The solution isnt perfect, it will overwrite template files on each run, so care must be taken to commit to git before running and inspect all changes.

Most of what is in the chart/ directory is boilerplate generated by Helmify. I made some modifications to modify the imagepullpolicy for debug purposes. I also added in a config map to hold the config for the workspace operator, and mounted it into the manager deployment. Care must be taken to retain these features. I put a warning in the README.

Other changes included modifying the Dockerfile directory structure so that templates can be loaded in as they are done when running the controller locally.

All tested on dev cluster, apphub now has persistent storage and workspaces are read correctly from remote repository via argocd source.

@UKEODHP/developers 