### PR TITLE
Updated events logic to ensure the events list is passed correctly to…

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -141,7 +141,7 @@ func main() {
 	// Create event client if pulsar URL is provided
 	var events *controller.EventsClient
 	if c.Pulsar.URL != "" {
-		events, err := controller.NewEventsClient(
+		events, err = controller.NewEventsClient(
 			c.Pulsar.URL, "workspace-controller")
 		if err != nil {
 			setupLog.Error(err, "could not create messaging client")


### PR DESCRIPTION
Updated main function to ensure updated `events` channel is available outside the if statement and is then passed correctly to the `NewWorkspaceReconciler`.
This previously meant the `events` channel was `nil` and no Pulsar messages were sent.  