### PR TITLE
EODHP-293 workflow access to workspace block stores

### DIFF
--- a/internal/controller/config.go
+++ b/internal/controller/config.go
@@ -122,25 +122,15 @@ func (r *ConfigReconciler) createConfigData(
 	}
 
 	type PVCMap struct {
-		PVCName       string `json:"pvcName"`
-		RootDirectory string `json:"rootDirectory"`
+		PVCName string `json:"pvcName"`
+		PVName  string `json:"pvName"`
 	}
 	var pvcMaps []PVCMap
 	for _, pvc := range spec.Storage.PersistentVolumeClaims {
-		for _, pv := range spec.Storage.PersistentVolumes {
-			if pv.Name == pvc.PVName {
-				for _, ap := range spec.AWS.EFS.AccessPoints {
-					if ap.Name == pv.VolumeSource.AccessPointName {
-						pvcMaps = append(pvcMaps, PVCMap{
-							PVCName:       pvc.Name,
-							RootDirectory: ap.RootDirectory,
-						})
-						break
-					}
-				}
-				break
-			}
-		}
+		pvcMaps = append(pvcMaps, PVCMap{
+			PVCName: pvc.Name,
+			PVName:  pvc.PVName,
+		})
 	}
 	pvcMapsJSON, err := json.Marshal(pvcMaps)
 	if err != nil {


### PR DESCRIPTION
Added mapping of pvc to rootdir to the configmap.
This appears as e.g:
pvcs:
[{"pvcName":"pvc-workspace","rootDirectory":"/workspaces/apalmer-tpzuk"}]
This facilitates pycalrissian (and other services) to determine the root directory correctly when there are multiple pvcs, or the directory may be different to the namespace.