### PR TITLE
attached inline policy to the workspace role to allow access to the s…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Tmp files
+.scratch/
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/templates/aws/policies/s3-workspace-policy.json
+++ b/templates/aws/policies/s3-workspace-policy.json
@@ -1,0 +1,25 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:{{ .region }}:{{ .accountID }}:accesspoint/{{ .accessPointName }}",
+                "arn:aws:s3:::{{ .bucketName }}"
+            ],
+            "Condition": {
+                "StringLike": {
+                    "s3:prefix": [
+                        "{{ .path }}*"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/templates/aws/policies/trust-policy.json
+++ b/templates/aws/policies/trust-policy.json
@@ -14,6 +14,13 @@
                     "{{.oidc.provider}}:sub": "system:serviceaccount:{{.namespace}}:{{.serviceAccount}}"
                 }
             }
+        },
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::{{.accountID}}:role/eodhp-dev-workspace-services-role"
+            },
+            "Action": "sts:AssumeRole"
         }
     ]
 }


### PR DESCRIPTION
- Amended the trust relationship to allow a workspace role to be trusted with the workspace-services role. This is currently hardcoded to the `dev` role. Didn't find an appropriate way to template it as the spec of the workspace knows nothing about workspace-services at the moment.

- Extended the permissions for the role to allow access to the dedicated access point's of each workspace bucket via templating
- Falls somewhere between iam and s3 in it's scope so it might be misplaced in terms of it's placement in the structure of the repo.